### PR TITLE
Update omniauth version constraints

### DIFF
--- a/omniauth-gitlab.gemspec
+++ b/omniauth-gitlab.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'omniauth', '~> 1.0'
+  gem.add_dependency 'omniauth', '~> 2.0.0'
   gem.add_dependency 'omniauth-oauth2', '>= 1.4.0', '< 2.0'
   gem.add_development_dependency 'rspec', '~> 3.1'
   gem.add_development_dependency 'rspec-its', '~> 1.0'


### PR DESCRIPTION
The current version of `omniauth` has a security [vulnerability](https://github.com/omniauth/omniauth/wiki/Resolving-CVE-2015-9284) addressed in versions >2.

This PR merely updates the version constraints in the gemspec.